### PR TITLE
migrate dn42bhs-burble from ca-bhs2 to us-nyc1

### DIFF
--- a/roles/config-bird2/config/peers/ymq/burble.conf
+++ b/roles/config-bird2/config/peers/ymq/burble.conf
@@ -1,5 +1,5 @@
 protocol bgp burble from dnpeers {
-    neighbor fd42:4242:2601:2d::1 as 4242422601;
+    neighbor fd42:4242:2601:29::1 as 4242422601;
 
     ipv4 {
         import where dn42_import_filter(3,24,34);

--- a/roles/config-wireguard/config/ymq.yml
+++ b/roles/config-wireguard/config/ymq.yml
@@ -29,10 +29,10 @@ wg_peers:
 
 - name: dn42bhs-burble
   port: 22601
-  remote: "dn42-ca-bhs2.burble.com:21080"
-  wg_pubkey: "gBePwGDpyxzsehvP9TZVB/XHgmS8tgv7oWtAru4K8iQ="
-  peer_v4: "172.20.129.167"
-  peer_v6: "fd42:4242:2601:2d::1/128"
+  remote: "dn42-us-nyc1.burble.com:21080"
+  wg_pubkey: "2mKKhhA5gz/rtIPtbz9b5wG6g5r4cdIYC/3/6My1SAw="
+  peer_v4: null
+  peer_v6: "fe80::42:2601:29:1"
 
 ### legacy configurations from ca-bhs01
 - name: dn42bhs-grmml


### PR DESCRIPTION
ca-bhs2 is being decommissioned and all peerings are being migrated to us-nyc1. 

This change updates our the dn42bhs-burble peering to the new node using a multi-protocol peering over link local IPv6 and expecting extended next hop.