### PR TITLE
tpa: migrate routedbits AS4242420207 peering from ATL to TPA

### DIFF
--- a/roles/config-wireguard/config/tpa.yml
+++ b/roles/config-wireguard/config/tpa.yml
@@ -36,8 +36,8 @@ wg_peers:
 
 - name: dn42-routedbits
   port: 20207
-  remote: router.atl1.routedbits.com:51080
-  wg_pubkey: QKK4a4vZQ4sd6EdXZ2IIlXNoUVMqcWX8nGoKEfy/VGU=
+  remote: router.mia1.routedbits.com:51080
+  wg_pubkey: 7v+CFwv6ptPDWWBtLoSJBq8+jC+jTD8QbRtt6NCYegw=
   peer_v4: null
   peer_v6: fe80::207
 


### PR DESCRIPTION
Previously we peered ATL to ATL, but seems you've retired your ATL node and migrated those sessions to TPA (Tampa). A closer peer would be MIA1 (Miami) for us so just simply moving the peering!

I have updated it on our side as well, so it will just come up when ready. I will tear down the other when I see this new one come up

Think that's all that needs to be changed, our link-local, etc stays the same so your BIRD configuration should remain the same