### PR TITLE
change cowgl endpoint

### DIFF
--- a/roles/config-wireguard/config/tyo.yml
+++ b/roles/config-wireguard/config/tyo.yml
@@ -451,7 +451,7 @@ wg_peers:
 
 - name: dn42-cowgl
   port: 23999
-  remote: cowgl.xyz:31080
+  remote: cowgl.us.kg:31080
   wg_pubkey: mGGBczSVKW+7UKRquI2GkbKrfxiATv9r4uF5WTP+vWI=
   peer_v4: 172.22.144.64
   peer_v6: fd36:62be:ef51::1


### PR DESCRIPTION
My domain `cowgl.xyz` has expired and will likely stop working soon, so I've changed my endpoint to another domain I own.