### PR TITLE
lon: add venkyt / AS4242421661

### DIFF
--- a/roles/config-wireguard/config/lon.yml
+++ b/roles/config-wireguard/config/lon.yml
@@ -515,3 +515,16 @@ wg_peers:
     extended_next_hop: true
 
 ## END peers moved from ams.peer
+
+- name: dn42-venkyt
+  port: 21661
+  remote: lon1.dn42.venkyt.com:51820
+  wg_pubkey: 9XWaLGXvh8ADe3wk/xY3jTBHmhFi4+5T8JBVuWMcFTQ=
+  peer_v4: 172.20.246.33
+  peer_v6: fe80::1661
+  bgp:
+    asn: 4242421661
+    ipv4: true
+    ipv6: true
+    mp_bgp: true
+    extended_next_hop: true


### PR DESCRIPTION
Adds WireGuard/BIRD peering config for AS4242421661 on the London node.

Validated with:
`python3 scripts/ci-verify.py .`